### PR TITLE
Allow for custom separators

### DIFF
--- a/lib/pwqgen/pwqgen.rb
+++ b/lib/pwqgen/pwqgen.rb
@@ -42,9 +42,9 @@ module Pwqgen
 	end
 
 	class Generator
-		def initialize
+		def initialize(separators = "-_!$&*+=23456789")
 			@@wordlist_size = @@wordlist.length
-			@@separators = "-_!$&*+=23456789".split(//)
+			@@separators = separators.split(//)
 			@@separators_size = @@separators.length
 			@rand = SecureRandom
 		end


### PR DESCRIPTION
There are some use cases where the hard-coded separators are not allowed as part of the password, so, it would make sense to allow callers to pass a custom list.
